### PR TITLE
Add `smallint` test, assorted docs to max-int branch

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -11,9 +11,9 @@ Test to see if number of rows is exactly 65,536 rows (cutoff by Excel)
 
 Returns **Object** describing the result
 
-### integerEquals2097152.js
+### maxSummedInteger.js
 
-[src/integerEquals2097152.js:13-65](https://github.com/dataproofer/core-suite/blob/master/src/integerEquals2097152.js#L13-L65 "Source code on GitHub")
+[src/maxSummedInteger.js:13-65](https://github.com/dataproofer/core-suite/blob/master/src/maxSummedInteger.js#L13-L65 "Source code on GitHub")
 
 Integers at their upper limit
 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -1,6 +1,6 @@
 ### numberOfRowsIs65k.js
 
-[src/numberOfRowsIs65k.js:12-31](https://github.com/dataproofer/core-suite/blob/b45d4fbd12f1b6c80c2dc14ba89c4dcbcce9a078/src/numberOfRowsIs65k.js#L12-L31 "Source code on GitHub")
+[src/numberOfRowsIs65k.js:12-31](https://github.com/dataproofer/core-suite/blob/master/src/numberOfRowsIs65k.js#L12-L31 "Source code on GitHub")
 
 Test to see if number of rows is exactly 65,536 rows (cutoff by Excel)
 
@@ -13,7 +13,7 @@ Returns **Object** describing the result
 
 ### integerEquals2097152.js
 
-[src/integerEquals2097152.js:13-65](https://github.com/dataproofer/core-suite/blob/b45d4fbd12f1b6c80c2dc14ba89c4dcbcce9a078/src/integerEquals2097152.js#L13-L65 "Source code on GitHub")
+[src/integerEquals2097152.js:13-65](https://github.com/dataproofer/core-suite/blob/master/src/integerEquals2097152.js#L13-L65 "Source code on GitHub")
 
 Integers at their upper limit
 
@@ -26,7 +26,7 @@ Returns **Object** describing the result
 
 ### checkDuplicateRows.js
 
-[src/checkDuplicateRows.js:13-73](https://github.com/dataproofer/core-suite/blob/b45d4fbd12f1b6c80c2dc14ba89c4dcbcce9a078/src/checkDuplicateRows.js#L13-L73 "Source code on GitHub")
+[src/checkDuplicateRows.js:13-73](https://github.com/dataproofer/core-suite/blob/master/src/checkDuplicateRows.js#L13-L73 "Source code on GitHub")
 
 Check for any duplicate rows in the spreadsheet. Optionally
 
@@ -40,7 +40,7 @@ Returns **Object** describing the result
 
 ### stringsHaveExactly255Characters.js
 
-[src/stringsHaveExactly255Characters.js:14-66](https://github.com/dataproofer/core-suite/blob/b45d4fbd12f1b6c80c2dc14ba89c4dcbcce9a078/src/stringsHaveExactly255Characters.js#L14-L66 "Source code on GitHub")
+[src/stringsHaveExactly255Characters.js:14-66](https://github.com/dataproofer/core-suite/blob/master/src/stringsHaveExactly255Characters.js#L14-L66 "Source code on GitHub")
 
 Determine the cells that have exactly 255 characters (SQL upper limit error). See ProPublica's bad data guide for further information
 <https://github.com/propublica/guides/blob/master/data-bulletproofing.md#integrity-checks-for-every-data-set>

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -15,7 +15,8 @@ Returns **Object** describing the result
 
 [src/maxSummedInteger.js:13-65](https://github.com/dataproofer/core-suite/blob/master/src/maxSummedInteger.js#L13-L65 "Source code on GitHub")
 
-Integers at their upper limit
+Integers at an upper limit, according to ProPublica's bad data guide:
+<https://github.com/propublica/guides/blob/master/data-bulletproofing.md#integrity-checks-for-every-data-set>
 
 **Parameters**
 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -11,6 +11,17 @@ Test to see if number of rows is exactly 65,536 rows (cutoff by Excel)
 
 Returns **Object** describing the result
 
+### maxSmallInteger.js
+
+[src/maxSmallInteger.js:15-71](https://github.com/dataproofer/core-suite/blob/master/src/maxSmallInteger.js#L15-L71 "Source code on GitHub")
+
+Integers at an upper limit when stored in [MySQL](https://dev.mysql.com/doc/refman/5.7/en/integer-types.html) or [PostgreSQL](http://www.postgresql.org/docs/9.5/interactive/datatype-numeric.html) `smallint` fields
+
+**Parameters**
+
+-   `rows` **Array** an array of objects representing rows in the spreadsheet
+-   `columnHeads` **Array** an array of strings for column names of the spreadsheet
+
 ### maxSummedInteger.js
 
 [src/maxSummedInteger.js:13-65](https://github.com/dataproofer/core-suite/blob/master/src/maxSummedInteger.js#L13-L65 "Source code on GitHub")

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -11,6 +11,17 @@ Test to see if number of rows is exactly 65,536 rows (cutoff by Excel)
 
 Returns **Object** describing the result
 
+### maxInteger.js
+
+[src/maxInteger.js:15-71](https://github.com/dataproofer/core-suite/blob/master/src/maxInteger.js#L15-L71 "Source code on GitHub")
+
+Integers at an upper limit when stored in [MySQL](https://dev.mysql.com/doc/refman/5.7/en/integer-types.html) signed `int` or [PostgreSQL](http://www.postgresql.org/docs/9.5/interactive/datatype-numeric.html) `integer` fields
+
+**Parameters**
+
+-   `rows` **Array** an array of objects representing rows in the spreadsheet
+-   `columnHeads` **Array** an array of strings for column names of the spreadsheet
+
 ### maxSmallInteger.js
 
 [src/maxSmallInteger.js:15-71](https://github.com/dataproofer/core-suite/blob/master/src/maxSmallInteger.js#L15-L71 "Source code on GitHub")

--- a/index.js
+++ b/index.js
@@ -11,11 +11,13 @@ var numberOfRowsIs65k = require('./src/numberOfRowsIs65k');
 var stringsHaveExactly255Characters = require('./src/stringsHaveExactly255Characters');
 var maxSummedInteger = require('./src/maxSummedInteger');
 var maxInteger = require('./src/maxInteger');
+var maxSmallInteger = require('./src/maxSmallInteger');
 
 exports.tests.push(
   numberOfRowsIs65k,
   checkDuplicateRows,
   stringsHaveExactly255Characters,
   maxSummedInteger,
-  maxInteger
+  maxInteger,
+  maxSmallInteger
 );

--- a/src/maxInteger.js
+++ b/src/maxInteger.js
@@ -52,7 +52,7 @@ maxInteger.name("Integers at their upper limit")
     var newSummary = _.template(`
       <% _.forEach(columnHeads, function(columnHead) { %>
         <% if(maxInts[columnHead]) { %>
-        <p class="test-value"><%= maxInts[columnHead] %></span> cells (<%= percent(maxInts[columnHead]/rows.length) %>) with a maximum summed integer in <span class="test-column"><%= columnHead %></p>
+        <p class="test-value"><%= maxInts[columnHead] %></span> cells (<%= percent(maxInts[columnHead]/rows.length) %>) with a maximum integer in <span class="test-column"><%= columnHead %></p>
         <% } %>
       <% }) %>
     `)({

--- a/src/maxSmallInteger.js
+++ b/src/maxSmallInteger.js
@@ -1,0 +1,73 @@
+var _ = require('lodash');
+var DataprooferTest = require('dataproofertest-js');
+var util = require('dataproofertest-js/util');
+var maxSmallInteger = new DataprooferTest();
+
+/**
+ * Indicates an `smallint` at its upper signed limit (MySQL or PostgreSQL) of 32,767 or its upper unsigned limit (MySQL) of 65,535.
+ * Common database programs, like MySQL, have a cap on how big of a number it can save.
+ * Please see the [MySQL documentation](https://dev.mysql.com/doc/refman/5.7/en/integer-types.html) or [PostgreSQL documentation](http://www.postgresql.org/docs/9.5/interactive/datatype-numeric.html) for more information.
+ *
+ * @param  {Array} rows - an array of objects representing rows in the spreadsheet
+ * @param  {Array} columnHeads - an array of strings for column names of the spreadsheet
+ * @return {Object} describing the result
+ */
+maxSmallInteger.name("Small integers at their upper limit")
+  .description("If a column contains numbers, make sure it's not 65,535 or 32,767. Common database programs like MySQL limit to the size of numbers it can store.")
+  .methodology(function(rows, columnHeads) {
+    var maxInts = {};
+    columnHeads.forEach(function(columnHead) {
+      maxInts[columnHead] = 0;
+    });
+    // we will want to mark cells to be highlighted here
+    var cells = [];
+    var passed = true;
+    // look through the rows
+    rows.forEach(function(row) {
+      // we make a row to keep track of cells we want to highlight
+      var currentRow = {}
+      columnHeads.forEach(function(columnHead) {
+        var cell = row[columnHead];
+        var f = parseFloat(cell);
+        // this will only be true if the cell is a number
+        if((f.toString() === cell || typeof cell === "number") && (f === 32767 || f === 65535)) {
+            maxInts[columnHead] += 1;
+            currentRow[columnHead] = 1;
+        } else {
+          currentRow[columnHead] = 0
+        }
+      })
+      // push our marking row onto our cells array
+      cells.push(currentRow)
+    });
+
+    // check if we found any max ints
+    // and change the value of passed to reflect that
+    if (_.isEmpty(maxInts) {
+      passed = true;
+    else{
+      passed = false;
+    }
+
+    var newSummary = _.template(`
+      <% _.forEach(columnHeads, function(columnHead) { %>
+        <% if(maxInts[columnHead]) { %>
+        <p class="test-value"><%= maxInts[columnHead] %></span> cells (<%= percent(maxInts[columnHead]/rows.length) %>) with a maximum small integer value in <span class="test-column"><%= columnHead %></p>
+        <% } %>
+      <% }) %>
+    `)({
+      columnHeads: columnHeads,
+      maxInts: maxInts,
+      rows: rows,
+      percent: util.percent
+    });
+
+    var result = {
+      passed: passed,
+      highlightCells: cells, // a mirror of the dataset, but with a 1 or 0 for each cell if it should be highlighted or not
+      summary: newSummary
+    }
+    return result;
+  });
+
+module.exports = maxSmallInteger;


### PR DESCRIPTION
See #6.

@geraldarthur [requested](https://github.com/dataproofer/core-suite/issues/6#issuecomment-203634506) either a `bigint` or a `smallint` test, and realistically, 9 quintillion or so isn't something we expect to see in data that often.

Also added some documentation for this test as well as the one that already had been added in this branch.