### PR TITLE
Add Char Encoding Check

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -1,20 +1,39 @@
-# stringsHaveExactly255Characters.js
+# conclusion
 
-[src/stringsHaveExactly255Characters.js:14-66](https://github.com/dataproofer/core-suite/blob/master/src/stringsHaveExactly255Characters.js#L14-L66 "Source code on GitHub")
+Calculates the percentage of rows that contain special, non-typical Latin characters for each column
+Source: <http://www.w3schools.com/charsets/ref_html_utf8.asp>
+
+**Parameters**
+
+-   `rows` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)** an array of objects representing rows in the spreadsheet
+-   `columnHeads` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)** an array of strings for column names of the spreadsheet
+
+Returns **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** describing the result
+
+# conclusion
+
+Calculates the percentage of rows that are empty for each column
+
+**Parameters**
+
+-   `rows` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)** an array of objects representing rows in the spreadsheet
+-   `columnHeads` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)** an array of strings for column names of the spreadsheet
+
+Returns **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** describing the result
+
+# methodology
 
 Determine the cells that have exactly 255 characters (SQL upper limit error). See ProPublica's bad data guide for further information
 <https://github.com/propublica/guides/blob/master/data-bulletproofing.md#integrity-checks-for-every-data-set>
 
 **Parameters**
 
--   `rows` **Array** an array of objects representing rows in the spreadsheet
--   `columnHeads` **Array** an array of strings for column names of the spreadsheet
+-   `rows` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)** an array of objects representing rows in the spreadsheet
+-   `columnHeads` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)** an array of strings for column names of the spreadsheet
 
-Returns **Object** describing the result
+Returns **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** describing the result
 
-# maxBigInteger.js
-
-[src/maxBigInteger.js:15-71](https://github.com/dataproofer/core-suite/blob/master/src/maxBigInteger.js#L15-L71 "Source code on GitHub")
+# methodology
 
 Indicates an `bigint` at its upper signed limit (MySQL or PostgreSQL) of 9,223,372,036,854,775,807 or its upper unsigned limit (MySQL) of 18,446,744,073,709,551,616.
 Common database programs, like MySQL, have a cap on how big of a number it can save.
@@ -22,14 +41,12 @@ Please see the [MySQL documentation](https://dev.mysql.com/doc/refman/5.7/en/int
 
 **Parameters**
 
--   `rows` **Array** an array of objects representing rows in the spreadsheet
--   `columnHeads` **Array** an array of strings for column names of the spreadsheet
+-   `rows` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)** an array of objects representing rows in the spreadsheet
+-   `columnHeads` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)** an array of strings for column names of the spreadsheet
 
-Returns **Object** describing the result
+Returns **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** describing the result
 
-# maxInteger.js
-
-[src/maxInteger.js:15-71](https://github.com/dataproofer/core-suite/blob/master/src/maxInteger.js#L15-L71 "Source code on GitHub")
+# methodology
 
 Indicates a integer at its upper signed limit is 2,147,483,647 (MySQL or PostgreSQL) or its upper unsigned limit (MySQL) of 4,294,967,295.
 Common database programs, like MySQL, have a cap on how big of a number it can save.
@@ -37,14 +54,12 @@ Please see the [MySQL documentation](https://dev.mysql.com/doc/refman/5.7/en/int
 
 **Parameters**
 
--   `rows` **Array** an array of objects representing rows in the spreadsheet
--   `columnHeads` **Array** an array of strings for column names of the spreadsheet
+-   `rows` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)** an array of objects representing rows in the spreadsheet
+-   `columnHeads` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)** an array of strings for column names of the spreadsheet
 
-Returns **Object** describing the result
+Returns **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** describing the result
 
-# maxSmallInteger.js
-
-[src/maxSmallInteger.js:15-71](https://github.com/dataproofer/core-suite/blob/master/src/maxSmallInteger.js#L15-L71 "Source code on GitHub")
+# methodology
 
 Indicates an `smallint` at its upper signed limit (MySQL or PostgreSQL) of 32,767 or its upper unsigned limit (MySQL) of 65,535.
 Common database programs, like MySQL, have a cap on how big of a number it can save.
@@ -52,48 +67,30 @@ Please see the [MySQL documentation](https://dev.mysql.com/doc/refman/5.7/en/int
 
 **Parameters**
 
--   `rows` **Array** an array of objects representing rows in the spreadsheet
--   `columnHeads` **Array** an array of strings for column names of the spreadsheet
+-   `rows` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)** an array of objects representing rows in the spreadsheet
+-   `columnHeads` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)** an array of strings for column names of the spreadsheet
 
-Returns **Object** describing the result
+Returns **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** describing the result
 
-# maxSummedInteger.js
-
-[src/maxSummedInteger.js:15-71](https://github.com/dataproofer/core-suite/blob/master/src/maxSummedInteger.js#L15-L71 "Source code on GitHub")
+# methodology
 
 Indicates a summed integers at its upper limit of 2,097,152.
 Please see the [Integrity Checks](https://github.com/propublica/guides/blob/master/data-bulletproofing.md#integrity-checks-for-every-data-set) section of the ProPublica [Data Bulletproofing Guide](https://github.com/propublica/guides/blob/master/data-bulletproofing.md) for more information.
 
 **Parameters**
 
--   `rows` **Array** an array of objects representing rows in the spreadsheet
--   `columnHeads` **Array** an array of strings for column names of the spreadsheet
+-   `rows` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)** an array of objects representing rows in the spreadsheet
+-   `columnHeads` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)** an array of strings for column names of the spreadsheet
 
-Returns **Object** describing the result
+Returns **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** describing the result
 
-# checkDuplicateRows.js
-
-[src/checkDuplicateRows.js:13-73](https://github.com/dataproofer/core-suite/blob/master/src/checkDuplicateRows.js#L13-L73 "Source code on GitHub")
-
-Check for any duplicate rows in the spreadsheet. Optionally
-
-**Parameters**
-
--   `rows` **Array** an array of objects representing rows in the spreadsheet
--   `columnHeads` **Array** an array of strings for column names of the spreadsheet
--   `input` **Object** accept user input, such as selected Columns
-
-Returns **Object** describing the result
-
-# numberOfRowsIs65k.js
-
-[src/numberOfRowsIs65k.js:12-31](https://github.com/dataproofer/core-suite/blob/master/src/numberOfRowsIs65k.js#L12-L31 "Source code on GitHub")
+# methodology
 
 Test to see if number of rows is exactly 65,536 rows (cutoff by Excel)
 
 **Parameters**
 
--   `rows` **Array** an array of objects representing rows in the spreadsheet
--   `columnHeads` **Array** an array of strings for column names of the spreadsheet
+-   `rows` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)** an array of objects representing rows in the spreadsheet
+-   `columnHeads` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)** an array of strings for column names of the spreadsheet
 
-Returns **Object** describing the result
+Returns **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** describing the result

--- a/README.md
+++ b/README.md
@@ -1,26 +1,52 @@
 # core-suite
+
 Core suite of tests for Dataproofer. These tests relate to common problems and data checks — namely, making sure data has not been truncated by looking for specific cut-off indicators.
 
-* [Documentation](https://github.com/dataproofer/core-suite/blob/master/README.md)
-* [Repository](https://github.com/dataproofer/core-suite/)
-* [Issues](https://github.com/dataproofer/core-suite/issues)
+-   [Documentation](https://github.com/dataproofer/core-suite/blob/master/README.md)
+-   [Repository](https://github.com/dataproofer/core-suite/)
+-   [Issues](https://github.com/dataproofer/core-suite/issues)
 
 ## Table of Contents
 
-* [Tests](https://github.com/dataproofer/core-suite#tests)
-  * [stringsHaveExactly255Characters.js](https://github.com/dataproofer/core-suite#stringsHaveExactly255Charactersjs)
-  * [maxBigInteger.js](https://github.com/dataproofer/core-suite#maxBigIntegerjs)
-  * [maxInteger.js](https://github.com/dataproofer/core-suite#maxIntegerjs)
-  * [maxSmallInteger.js](https://github.com/dataproofer/core-suite#maxSmallIntegerjs)
-  * [maxSummedInteger.js](https://github.com/dataproofer/core-suite#maxSummedIntegerjs)
-  * [checkDuplicateRows.js](https://github.com/dataproofer/core-suite#checkDuplicateRowsjs)
-  * [numberOfRowsIs65k.js](https://github.com/dataproofer/core-suite#numberOfRowsIs65kjs)
-* [Development](https://github.com/dataproofer/core-suite#development)
-  * [Getting Started](https://github.com/dataproofer/core-suite#getting-started)
-  * [Writing Tests](https://github.com/dataproofer/stats-suite#writing-tests)
-  * [Building Docs](https://github.com/dataproofer/core-suite#building-docs)
+-   [Tests](https://github.com/dataproofer/core-suite#tests)
+    -   [columnsContainNothing.js](https://github.com/dataproofer/core-suite#columnsContainNothing.js)
+    -   [columnsContainsSpecialChars](https://github.com/dataproofer/core-suite#columnsContainsSpecialChars.js)
+    -   [stringsHaveExactly255Characters.js](https://github.com/dataproofer/core-suite#stringsHaveExactly255Charactersjs)
+    -   [maxBigInteger.js](https://github.com/dataproofer/core-suite#maxBigIntegerjs)
+    -   [maxInteger.js](https://github.com/dataproofer/core-suite#maxIntegerjs)
+    -   [maxSmallInteger.js](https://github.com/dataproofer/core-suite#maxSmallIntegerjs)
+    -   [maxSummedInteger.js](https://github.com/dataproofer/core-suite#maxSummedIntegerjs)
+    -   [checkDuplicateRows.js](https://github.com/dataproofer/core-suite#checkDuplicateRowsjs)
+    -   [numberOfRowsIs65k.js](https://github.com/dataproofer/core-suite#numberOfRowsIs65kjs)
+-   [Development](https://github.com/dataproofer/core-suite#development)
+    -   [Getting Started](https://github.com/dataproofer/core-suite#getting-started)
+    -   [Writing Tests](https://github.com/dataproofer/stats-suite#writing-tests)
+    -   [Building Docs](https://github.com/dataproofer/core-suite#building-docs)
 
 ## Tests
+
+# columnsContainNothing.js
+
+Calculates the percentage of rows that are empty for each column
+
+**Parameters**
+
+-   `rows` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)** an array of objects representing rows in the spreadsheet
+-   `columnHeads` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)** an array of strings for column names of the spreadsheet
+
+Returns **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** describing the result
+
+# columnsContainsSpecialChars.js
+
+Calculates the percentage of rows that contain special, non-typical Latin characters for each column
+Source: <http://www.w3schools.com/charsets/ref_html_utf8.asp>
+
+**Parameters**
+
+-   `rows` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)** an array of objects representing rows in the spreadsheet
+-   `columnHeads` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)** an array of strings for column names of the spreadsheet
+
+Returns **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** describing the result
 
 # stringsHaveExactly255Characters.js
 
@@ -126,26 +152,22 @@ Returns **Object** describing the result
 
 ### Getting Started
 
-```
-git clone git@github.com:dataproofer/core-suite.git
-cd core-suite
-npm install
-```
+    git clone git@github.com:dataproofer/core-suite.git
+    cd core-suite
+    npm install
 
 ### Writing Tests
 
-* [How to](https://github.com/dataproofer/Dataproofer#creating-a-new-test)
-* [Helper Scripts](https://github.com/dataproofer/dataproofertest-js/blob/master/DOCUMENTATION.md#util)
-* Templates
-  * [Basic Test](https://github.com/dataproofer/suite-template/blob/master/src/myTest.js)
-  * [Advanced Test](https://github.com/dataproofer/suite-template/blob/master/src/myAdvancedTest.js)
+-   [How to](https://github.com/dataproofer/Dataproofer#creating-a-new-test)
+-   [Helper Scripts](https://github.com/dataproofer/dataproofertest-js/blob/master/DOCUMENTATION.md#util)
+-   Templates
+    -   [Basic Test](https://github.com/dataproofer/suite-template/blob/master/src/myTest.js)
+    -   [Advanced Test](https://github.com/dataproofer/suite-template/blob/master/src/myAdvancedTest.js)
 
 ### Building Docs
 
 We use [documentation.js](https://github.com/documentationjs/documentation), but have created a handy script for regenerating documentation.
 
-```
-npm run docs
-```
+    npm run docs
 
 Then open up and check your docs in [DOCUMENTATION.md](https://github.com/dataproofer/info-suite/blob/master/DOCUMENTATION.md)

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ exports = module.exports = {
 };
 
 var columnsContainNothing = require("./src/columnsContainNothing");
+var columnsContainsOddChars = require("./src/columnsContainsOddChars");
 var checkDuplicateRows = require("./src/checkDuplicateRows");
 var maxInteger = require("./src/maxInteger");
 var maxSmallInteger = require("./src/maxSmallInteger");
@@ -17,6 +18,7 @@ var stringsHaveExactly255Characters = require("./src/stringsHaveExactly255Charac
 
 exports.tests.push(
   columnsContainNothing,
+  columnsContainsOddChars,
   checkDuplicateRows,
   numberOfRowsIs65k,
   stringsHaveExactly255Characters,

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ exports = module.exports = {
 };
 
 var columnsContainNothing = require("./src/columnsContainNothing");
-var columnsContainsOddChars = require("./src/columnsContainsOddChars");
+var columnsContainsSpecialChars = require("./src/columnsContainsSpecialChars");
 var checkDuplicateRows = require("./src/checkDuplicateRows");
 var maxInteger = require("./src/maxInteger");
 var maxSmallInteger = require("./src/maxSmallInteger");
@@ -18,7 +18,7 @@ var stringsHaveExactly255Characters = require("./src/stringsHaveExactly255Charac
 
 exports.tests.push(
   columnsContainNothing,
-  columnsContainsOddChars,
+  columnsContainsSpecialChars,
   checkDuplicateRows,
   numberOfRowsIs65k,
   stringsHaveExactly255Characters,

--- a/src/columnsContainNothing.js
+++ b/src/columnsContainNothing.js
@@ -41,7 +41,7 @@ columnsContainNothing.name("Empty Cells")
   })
   .conclusion(function(result) {
     var conclusionStr = "";
-    var columns = _.keys(result.columnWise);
+    var columns = Object.keys(result.columnWise);
     columns.forEach(function(column) {
       // Column foo:
       var currCount = result.columnWise[column];
@@ -53,6 +53,6 @@ columnsContainNothing.name("Empty Cells")
       }
     });
     return conclusionStr;
-  })
+  });
 
 module.exports =  columnsContainNothing;

--- a/src/columnsContainNothing.js
+++ b/src/columnsContainNothing.js
@@ -46,10 +46,10 @@ columnsContainNothing.name("Empty Cells")
       // Column foo:
       var currCount = result.columnWise[column];
       if (currCount > 0) {
-        conclusionStr += column + ": ";
+        conclusionStr += "column \"" + column + "\": ";
         conclusionStr += result.columnWise[column] + " cells, ";
         conclusionStr += util.percent(result.columnWise[column] / result.highlightCells.length);
-        conclusionStr += " of column <br>";
+        conclusionStr += "<br>";
       }
     });
     return conclusionStr;

--- a/src/columnsContainsOddChars.js
+++ b/src/columnsContainsOddChars.js
@@ -1,6 +1,5 @@
 var DataprooferTest = require("dataproofertest-js");
 var util = require("dataproofertest-js/util")
-var _ = require("lodash");
 var columnsContainsOddChars = new DataprooferTest();
 
 /**
@@ -23,9 +22,9 @@ columnsContainsOddChars.name("Odd Letters & Characters")
       // look for characters outside typical Latin
       // character codes
       // http://www.w3schools.com/charsets/ref_html_utf8.asp
-      _.forEach(str, function(char) {
-        if (char.charCodeAt() > 255) result = true;
-      });
+      for (var i=0; i<str.length; i++) {
+        if (str.charCodeAt(i) > 127) result = true
+      }
       return result;
     }
     // look through the rows

--- a/src/columnsContainsOddChars.js
+++ b/src/columnsContainsOddChars.js
@@ -1,7 +1,7 @@
 var DataprooferTest = require("dataproofertest-js");
-var util = require("dataproofertest-js/util");
-
-var columnsContainNothing = new DataprooferTest();
+var util = require("dataproofertest-js/util")
+var _ = require("lodash");
+var columnsContainsOddChars = new DataprooferTest();
 
 /**
 * Calculates the percentage of rows that are empty for each column
@@ -10,19 +10,27 @@ var columnsContainNothing = new DataprooferTest();
  * @param  {Array} columnHeads - an array of strings for column names of the spreadsheet
  * @return {Object} describing the result
  */
-columnsContainNothing.name("Empty Cells")
-  .description("Calculates the percentage of rows that are empty for each column")
-  .methodology(function(rows, columnHeads) {
+columnsContainsOddChars.name("Odd Letters & Characters")
+  .description("Determine which cells contain odd characters. These can cause errors with some visualization & analysis tools.")
+  .methodology(function (rows, columnHeads) {
     var testState = "passed";
     // we will want to mark cells to be highlighted here
     var cellsToHighlight = [];
+
+    function containsOddChar(str) {
+      var result = false;
+      _.forEach(str, function(char) {
+        if (char.charCodeAt() > 255) result = true;
+      });
+      return result;
+    }
     // look through the rows
     rows.forEach(function(row) {
       // we make a row to keep track of cells we want to highlight
       var currentRow = {};
       columnHeads.forEach(function(columnHead) {
         var cell = row[columnHead];
-        if (util.isEmpty(cell)) {
+        if (util.isString(cell) && containsOddChar(cell)) {
           currentRow[columnHead] = 1;
           testState = "warn";
         } else {
@@ -32,7 +40,6 @@ columnsContainNothing.name("Empty Cells")
       // push our marking row onto our cells array
       cellsToHighlight.push(currentRow);
     });
-
     var result = {
       testState: testState,
       highlightCells: cellsToHighlight
@@ -53,6 +60,7 @@ columnsContainNothing.name("Empty Cells")
       }
     });
     return conclusionStr;
-  })
+  });
 
-module.exports =  columnsContainNothing;
+
+module.exports =  columnsContainsOddChars;

--- a/src/columnsContainsOddChars.js
+++ b/src/columnsContainsOddChars.js
@@ -4,7 +4,8 @@ var _ = require("lodash");
 var columnsContainsOddChars = new DataprooferTest();
 
 /**
-* Calculates the percentage of rows that are empty for each column
+* Calculates the percentage of rows that contain odd characters for each column
+* Source: http://www.w3schools.com/charsets/ref_html_utf8.asp
 *
  * @param  {Array} rows - an array of objects representing rows in the spreadsheet
  * @param  {Array} columnHeads - an array of strings for column names of the spreadsheet
@@ -19,6 +20,9 @@ columnsContainsOddChars.name("Odd Letters & Characters")
 
     function containsOddChar(str) {
       var result = false;
+      // look for characters outside typical Latin
+      // character codes
+      // http://www.w3schools.com/charsets/ref_html_utf8.asp
       _.forEach(str, function(char) {
         if (char.charCodeAt() > 255) result = true;
       });
@@ -50,7 +54,7 @@ columnsContainsOddChars.name("Odd Letters & Characters")
     var conclusionStr = "";
     var columns = _.keys(result.columnWise);
     columns.forEach(function(column) {
-      // Column foo:
+      // generate result string
       var currCount = result.columnWise[column];
       if (currCount > 0) {
         conclusionStr += column + ": ";

--- a/src/columnsContainsSpecialChars.js
+++ b/src/columnsContainsSpecialChars.js
@@ -1,5 +1,5 @@
 var DataprooferTest = require("dataproofertest-js");
-var util = require("dataproofertest-js/util")
+var util = require("dataproofertest-js/util");
 var columnsContainsSpecialChars = new DataprooferTest();
 
 /**
@@ -23,7 +23,7 @@ columnsContainsSpecialChars.name("Special Letters & Characters")
       // character codes
       // http://www.w3schools.com/charsets/ref_html_utf8.asp
       for (var i=0; i<str.length; i++) {
-        if (str.charCodeAt(i) > 127) result = true
+        if (str.charCodeAt(i) > 127) result = true;
       }
       return result;
     }
@@ -51,7 +51,7 @@ columnsContainsSpecialChars.name("Special Letters & Characters")
   })
   .conclusion(function(result) {
     var conclusionStr = "";
-    var columns = _.keys(result.columnWise);
+    var columns = Object.keys(result.columnWise);
     columns.forEach(function(column) {
       // generate result string
       var currCount = result.columnWise[column];

--- a/src/columnsContainsSpecialChars.js
+++ b/src/columnsContainsSpecialChars.js
@@ -3,13 +3,13 @@ var util = require("dataproofertest-js/util");
 var columnsContainsSpecialChars = new DataprooferTest();
 
 /**
-* Calculates the percentage of rows that contain Special characters for each column
+* Calculates the percentage of rows that contain special, non-typical Latin characters for each column
 * Source: http://www.w3schools.com/charsets/ref_html_utf8.asp
 *
- * @param  {Array} rows - an array of objects representing rows in the spreadsheet
- * @param  {Array} columnHeads - an array of strings for column names of the spreadsheet
- * @return {Object} describing the result
- */
+* @param  {Array} rows - an array of objects representing rows in the spreadsheet
+* @param  {Array} columnHeads - an array of strings for column names of the spreadsheet
+* @return {Object} describing the result
+*/
 columnsContainsSpecialChars.name("Special Letters & Characters")
   .description("Determine which cells contain wingdings, boxes, or accented characters. These can cause errors with some visualization & analysis tools.")
   .methodology(function (rows, columnHeads) {

--- a/src/columnsContainsSpecialChars.js
+++ b/src/columnsContainsSpecialChars.js
@@ -1,23 +1,23 @@
 var DataprooferTest = require("dataproofertest-js");
 var util = require("dataproofertest-js/util")
-var columnsContainsOddChars = new DataprooferTest();
+var columnsContainsSpecialChars = new DataprooferTest();
 
 /**
-* Calculates the percentage of rows that contain odd characters for each column
+* Calculates the percentage of rows that contain Special characters for each column
 * Source: http://www.w3schools.com/charsets/ref_html_utf8.asp
 *
  * @param  {Array} rows - an array of objects representing rows in the spreadsheet
  * @param  {Array} columnHeads - an array of strings for column names of the spreadsheet
  * @return {Object} describing the result
  */
-columnsContainsOddChars.name("Odd Letters & Characters")
-  .description("Determine which cells contain odd characters. These can cause errors with some visualization & analysis tools.")
+columnsContainsSpecialChars.name("Special Letters & Characters")
+  .description("Determine which cells contain wingdings, boxes, or accented characters. These can cause errors with some visualization & analysis tools.")
   .methodology(function (rows, columnHeads) {
     var testState = "passed";
     // we will want to mark cells to be highlighted here
     var cellsToHighlight = [];
 
-    function containsOddChar(str) {
+    function containsSpecialChar(str) {
       var result = false;
       // look for characters outside typical Latin
       // character codes
@@ -33,7 +33,7 @@ columnsContainsOddChars.name("Odd Letters & Characters")
       var currentRow = {};
       columnHeads.forEach(function(columnHead) {
         var cell = row[columnHead];
-        if (util.isString(cell) && containsOddChar(cell)) {
+        if (util.isString(cell) && containsSpecialChar(cell)) {
           currentRow[columnHead] = 1;
           testState = "warn";
         } else {
@@ -66,4 +66,4 @@ columnsContainsOddChars.name("Odd Letters & Characters")
   });
 
 
-module.exports =  columnsContainsOddChars;
+module.exports =  columnsContainsSpecialChars;


### PR DESCRIPTION
Fixes https://github.com/dataproofer/Dataproofer/issues/5

**Summary**

Add basic check for any characters above character code 255. These get into windings, boxes, and more unique accented characters. This test is meant to be easily editable if these character codes catch too many cells, like if you're using this in a different language.

**Proposed changes**

Provide a few more details like what files were modified, added or removed.

* What was modified: added conclusion to `columnContainsNothin.js`
* What was added:
  * new check `columnContainsOddNumbers.js`
  * new real world datasets in sample-datasets
    * `bad-encoding-countries.csv`
    * `bad-encoding-census.csv`
* Next actions:
  - [ ] review & approval by @ejfox 

cc @dataproofer/core